### PR TITLE
adiciona challenge do GitHub para o (sub)domínio frevo.ruby.com.br

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -54,9 +54,9 @@ locals {
     # Frevo on Rails (frevo.ruby.com.br)
     # frevo.ruby.com.br -> https://github.com/frevo-on-rails/frevo-on-rails.github.com
     frevo = {
-      type  = "CNAME"
-      name  = "frevo.ruby.com.br"
-      value = "frevo-on-rails.github.io"
+      type  = "TXT"
+      name  = "_github-pages-challenge-embs.frevo.ruby.com.br"
+      value = "a5e75b0c0b048f320add8945e88165"
     }
 
     # Frevo on Rails (pe.ruby.com.br)


### PR DESCRIPTION
Nosso subdomínio já está em uso e servindo uma página estranhíssima:

![image](https://github.com/wagner/dns-ruby-com-br/assets/1200033/67ce0b7d-26fd-4cf8-8be7-7b547d2a2a53)

Precisamos adicionar essa challenge do GitHub para verificar a propriedade do domínio de acordo com a documentação do GitHub: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages