### PR TITLE
Mudando o empresas.ruby.com.br para outro servidor

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -30,9 +30,11 @@ locals {
     # Diretório de empresas Ruby criado pela Le Wagon e Tropical.rb
     # empresas.ruby.com.br -> vast-guineafowl-iu7hx8tx58o0h63miig7mtb0.herokudns.com
     empresas = {
-      type  = "CNAME"
+      type  = "A"
       name  = "empresas.ruby.com.br"
-      value = "vast-guineafowl-iu7hx8tx58o0h63miig7mtb0.herokudns.com"
+      value = [
+        "66.241.125.4"
+      ]
     }
 
     # Redirecionamento tropical.ruby.com.br


### PR DESCRIPTION
O empresas.ruby.com.br ficou fora do ar devido ao fim da gratuidade do Heroku. Trouxe ele para um servidor custeado pela Linkana no fly.io